### PR TITLE
feat: get rid of poetry dependency in version checker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = custom_hooks
-version = 1.2.1
-description = Some random custom hooks.
+version = 1.3.0
+description = Just some hooks that help save some time ...and nerves.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/OriginalUtkin/custom-hooks

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 
+function is_output_valid() {
+    line_numbers=$(eval "echo $1 | wc -l")
+    is_version_correct=$(eval "echo $1 | grep -E '[0-9.]?'")
+
+    if [[ ($line_numbers -eq 1)  && (! -z $is_version_correct)]]; then
+        return 0
+    else
+        return 1
+    fi
+
+}
+
 if [[ ("$1" == "poetry") ]]; then
   version_file="pyproject.toml"
-  command="grep -E '^version'|sed 's/\"//g'|sed -E 's/version[[:blank:]]?=[[:blank:]]?//g'"
+  command="sed 's/[\ \"]*//g' | grep -E '(^\[tool\.poetry\])|(^version)' | sed -E 's/\[tool.poetry\]//g' | sed -E 's/version[[:blank:]]?=[[:blank:]]?//g'"
 
 elif [[ ("$1" == "version_file") ]]; then
   version_file="VERSION"
@@ -13,11 +25,17 @@ else
   exit 1
 fi
 
+
 version_in_branch=$(eval "cat $version_file | $command")
 
 git fetch -q origin master
 
 version_in_master=$(eval "git show origin/master:$version_file | $command")
+
+if (! is_output_valid $version_in_branch) || (! is_output_valid $version_in_master); then
+    echo "Version update is not correct"
+    exit 1
+fi
 
 echo "Version in branch:" $version_in_branch
 echo "Version in master:" $version_in_master

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,31 +1,31 @@
 #!/usr/bin/env bash
 
-if [[ ("$2" == "poetry") || (("$2" == "") && ( -f pyproject.toml)) ]]; then
+if [[ ("$1" == "poetry") ]]; then
   version_file="pyproject.toml"
-  command="poetry version -s"
-elif [[ ("$2" == "version_file") || (("$2" == "") && ( -f VERSION)) ]]; then
+  command="grep -E '^version'|sed 's/\"//g'|sed -E 's/version[[:blank:]]?=[[:blank:]]?//g'"
+
+elif [[ ("$1" == "version_file") ]]; then
   version_file="VERSION"
-  command="cat VERSION"
+  command="grep -E '[0-9.]+'"
+
 else
-  echo "Version type '$2' not supported"
+  echo "Version type '$1' not supported"
   exit 1
 fi
 
-tfile=$(mktemp $version_file.XXXXXXXXX)
-mv $version_file $tfile
+version_in_branch=$(eval "cat $version_file | $command")
+
 git fetch -q origin master
-git checkout master -q -- $version_file
-version_in_master=$($command)
-mv $tfile $version_file
-version_in_branch=$($command)
+
+version_in_master=$(eval "git show origin/master:$version_file | $command")
 
 echo "Version in branch:" $version_in_branch
 echo "Version in master:" $version_in_master
 
-changed_files=$(git diff origin/master --summary --name-only |  grep -E $1)
+changed_files=$(git diff origin/master --summary --name-only |  grep -E $2)
 
 if [[ ("$version_in_branch" == "$version_in_master") && (! -z $changed_files)]]
 then
-  echo "VERSION file is not updated"
+  echo "Version in $version_file file is not updated"
   exit 1
 fi


### PR DESCRIPTION
In previous release poetry dependency was introduced in order to be able check version of poetry file. It was done as quick solution just to make it works. 

This merge request removes such dependency in order not to relate on it inside the container it is being run in CI/CD container.